### PR TITLE
Error message when server return error on proposal submission.

### DIFF
--- a/app/scripts/speaker/SubmitProposal.js
+++ b/app/scripts/speaker/SubmitProposal.js
@@ -297,6 +297,10 @@ function ($q, $scope, $filter, UserService, Tags, TalksService, EventService, $r
                 $location.path('/speaker/proposals');
             }, function (data) {
                 $scope.isSubmitted = false;
+                $scope.feedback = {
+                    type: 'error',
+                    message: 'Failed to submit your proposal, please try again'
+                };
             });
         }
     };

--- a/app/views/speaker/proposal_form.html
+++ b/app/views/speaker/proposal_form.html
@@ -23,6 +23,11 @@
         </h4>
 
         <form name="submitProposalForm" onsubmit="return false" ng-cloak ng-hide="isSubmitted">
+            <div class="row" ng-show="feedback">
+                <div class="col12 push3">
+                    <div class="alert alert-{{feedback.type}}" ng-show="feedback">{{feedback.message}}</div>
+                </div>
+            </div>
             <div class="row">
                 <div class="col16">
                     <h4>Proposal</h4>
@@ -209,6 +214,11 @@
                         </li>
                     </ul>
 
+                </div>
+            </div>
+            <div class="row" ng-show="feedback">
+                <div class="col12 push3">
+                    <div class="alert alert-{{feedback.type}}" ng-show="feedback">{{feedback.message}}</div>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
Added error message on page of proposal submission when the server fails to register the proposal.
Message is added at the top and bottom of the page to be sure that user will see it.
This pull request is an attempt to part of issue #50 and issue #51 
