### PR TITLE
add myschedule filter + add favorite management in speaker talks page + login

### DIFF
--- a/app/index.hbr.html
+++ b/app/index.hbr.html
@@ -103,6 +103,41 @@
                     <li class="btn hide_mobile">
                     <a href="https://regbe.devoxx.com/public#DV13">Sold Out</a>
                     </li>
+                    <li class="btn popup login btn_grey" class="open" id="login">
+                        <a>Login</a>
+                        <ul nclass="visible">
+                            <li>
+                                <div class="popup">
+                                    <form class="clearfix" autocomplete="off">
+                                        <div class="alert alert-error" style="display: none"></div>
+                                        <input type="text" name="login" value="" placeholder="E-mail" onkeydown="if (event.keyCode == 13) staticlogin()"/>
+                                        <input type="password" name="pass" value="" placeholder="Password" onkeydown="if (event.keyCode == 13) staticlogin()"/>
+                                        <a href="/#/register" class="btnRegister">Register</a>
+                                        <input type="button" class="btn" onclick="staticlogin()" value="Login"/>
+                                    </form>
+
+                                    <div class="connect clearfix hidden">
+                                        <a href="#" class="btnFacebook">Facebook</a>
+                                        <a href="#" class="btnTwitter">Twitter</a>
+                                        <a href="#" class="btnLinkedin">LinkedIn</a>
+                                        <a href="#" class="btnGoogle">Google+</a>
+                                    </div>
+
+                                    <div class="actionslinks clearfix">
+                                        <a href="/#/lost_password" class="btnForgot">Forgot password</a>
+                                    </div>
+                                </div>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="submenu subright" id="logged" style="display: none">
+                        <a><span id="userNames"></span> <img src="images/User-icon.png" height="10" width="10" style="margin-top: -1px;"></a>
+                        <ul>
+                            <li><a href="/" onclick="staticlogout()">Logout</a></li>
+                            <li><a href="/#/speaker/proposals">Proposals</a></li>
+                            <li><a href="/#/speaker/profile">Profile</a></li>
+                        </ul>
+                    </li>
 
                     <li class="popup search">
                         <a href="#">Search</a>

--- a/app/scheduleBody.hbr.html
+++ b/app/scheduleBody.hbr.html
@@ -58,7 +58,9 @@
 					<li>
 						<a href="#" class="button selected dataday" id="day-5Button">Friday</a>
 					</li>
-
+					<li>
+						<a href="#" class="button myschedule">My Schedule</a>
+					</li>
 				</ul>
 			
 			</div>
@@ -272,20 +274,26 @@
 
 	$(".button").click(function() {
 	    $(this).toggleClass('selected');
-	
+
 	    $(".trackFilter").hide();
-	
+
 	    var datatracks = $(".trackFilter");
-	
+
+	    if ( $(".button.selected.myschedule").length ) {
+	        datatracks = datatracks.filter(function() {
+	            return $( ".favorite.on", this ).length;
+	        });
+	    }
+
 	    $(".button.datatrack").not('.selected').each(function() {
 	        var selClass = $(this).attr('id').replace('Button', '');
-	
+
 	        datatracks = datatracks.filter(".trackFilter[data-track!='" + selClass + "']");
 	    });
-	
+
 	    $(".button.selected.dataday").each(function() {
 	        var selClass = $(this).attr('id').replace('Button', '');
-	
+
 	        datatracks.filter(".trackFilter[data-day='" + selClass + "']").show();
 	    });
 	});

--- a/app/scripts/favorite.js
+++ b/app/scripts/favorite.js
@@ -123,6 +123,8 @@ function manageFavoritesLinks() {
                         bindFavoriteButton(presId, true, link, false);
                     });
                 });
+        }).fail(function () {
+            $('.button.myschedule').hide();
         });
 }
 

--- a/app/speakerBody.hbr.html
+++ b/app/speakerBody.hbr.html
@@ -68,7 +68,7 @@
             
                 <p>{{nlbr summary}}</p>
 
-                <a href="javascript:void(0)" class="btn" id="addToFavorites" style="display: none"></a> <br><br>
+                <a href="javascript:void(0)" class="btn" id="addToFavorites{{id}}" style="display: none"></a> <br><br>
                 
                 {{#if parleysIds}}
                 <iframe class="parleysEmbed" type="text/html" width="420" height="220" mozallowfullscreen="true" webkitallowfullscreen="true" src="http://parleys.com/share.html#play/{{parleysIds}}" frameborder="0">&amp;lt;br /&amp;gt;</iframe>
@@ -179,6 +179,6 @@
         }, 500);
     }
 
-    managePresentationFavorite(presId);
+    manageFavoritesLinks(presId);
 
 </script>


### PR DESCRIPTION
- [x] As a devoxian, I want to see my favorites talks in schedule page to know which talk I (have|will) attend. (in: http://www.devoxx.be/dv13-schedule.html)
- [x] As a devoxian, I want to had talks of my favorite speaker in my schedule on speaker page in order to be a good fan! (in: http://www.devoxx.be/dv13-filip-maelbrancke.html?presId=3667)
- [x] As a devoxian, I want to login/logout in schedule pages in order to see my schedule easily

NB: Added a MySchedule button filter in schedule page. Button is hidden if user is not logged and is unselected by default.

@jayv @stephanj 
